### PR TITLE
Convert menu bar to MUI tabs

### DIFF
--- a/web/components/siteMenu.js
+++ b/web/components/siteMenu.js
@@ -7,6 +7,9 @@ import { siteSections, siteSourceUrl } from "../lib/settings";
 import styles from './siteMenu.module.css';
 
 export default function SiteMenu() {
+    const appBarElevation = 0;
+    const menuIconSize = 24;
+
     const MenuItem = (section) => {
         const isCurrentSection = (section.href === `/${getCurrentSection()}`);
         const menuItemClass = isCurrentSection ? styles.menuItemActive : styles.menuItem;
@@ -14,10 +17,10 @@ export default function SiteMenu() {
         return (
             <Tab component={Link} className={menuItemClass} href={section.href} label={section.name} />
         )
-    }
+    };
 
     return (
-        <AppBar position="static" elevation={0} sx={{ margin: "0" }}>
+        <AppBar position="static" elevation={appBarElevation} >
             <Tabs>
                 {siteSections.map((section) => {
                     return MenuItem(section)
@@ -25,8 +28,7 @@ export default function SiteMenu() {
                 <Tab component={Link}
                     className={styles.menuItemRight}
                     href={siteSourceUrl}
-                    icon={<MarkGithubIcon verticalAlign="middle" size={24} />}
-                    sx={{ width: "30px" }}
+                    icon={<MarkGithubIcon verticalAlign="middle" size={menuIconSize} />}
                 />
             </Tabs>
         </AppBar >

--- a/web/components/siteMenu.js
+++ b/web/components/siteMenu.js
@@ -22,7 +22,12 @@ export default function SiteMenu() {
                 {siteSections.map((section) => {
                     return MenuItem(section)
                 })}
-                <Tab component={Link} className={styles.menuItemRight} href={siteSourceUrl} icon={<MarkGithubIcon verticalAlign="middle" size={24} />} sx={{ width: "30px" }} />
+                <Tab component={Link}
+                    className={styles.menuItemRight}
+                    href={siteSourceUrl}
+                    icon={<MarkGithubIcon verticalAlign="middle" size={24} />}
+                    sx={{ width: "30px" }}
+                />
             </Tabs>
         </AppBar >
     );

--- a/web/components/siteMenu.js
+++ b/web/components/siteMenu.js
@@ -1,46 +1,29 @@
 import Link from 'next/link';
 import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Tooltip from '@mui/material/Tooltip';
-import { Typography } from '@mui/material';
+import { Tab, Tabs } from "@mui/material"
 import { MarkGithubIcon } from '@primer/octicons-react'
 import { getCurrentSection } from '../lib/utils';
 import { siteSections, siteSourceUrl } from "../lib/settings";
-import { Tab, Tabs } from "@mui/material"
 import styles from './siteMenu.module.css';
 
 export default function SiteMenu() {
     const MenuItem = (section) => {
         const isCurrentSection = (section.href === `/${getCurrentSection()}`);
-        const typographyClass = isCurrentSection ? styles.menuItemActive : styles.menuItem;
-        const linkClass = isCurrentSection ? styles.menuLinkActive : styles.menuLink;
+        const menuItemClass = isCurrentSection ? styles.menuItemActive : styles.menuItem;
 
         return (
-            <Typography component="div" className={typographyClass}>
-                <Link className={linkClass} href={section.href}>
-                    {section.name}
-                </Link>
-            </Typography>
+            <Tab component={Link} className={menuItemClass} href={section.href} label={section.name} />
         )
     }
 
     return (
-        <AppBar position="static" elevation={0} sx={{ height: "3rem", margin: "0" }}>
-            <Toolbar variant="dense">
-                <Box display="flex" flexGrow={1} sx={{ height: "100%" }}>
-                    {siteSections.map((section) => {
-                        return MenuItem(section)
-                    })}
-                </Box>
-                <Tooltip title="view source code for this site">
-                    <Typography component="div" className={styles.menuItem}>
-                        <Link className={styles.menuLink} href={siteSourceUrl}>
-                            <MarkGithubIcon verticalAlign="middle" size={24} />
-                        </Link>
-                    </Typography>
-                </Tooltip>
-            </Toolbar>
+        <AppBar position="static" elevation={0} sx={{ margin: "0" }}>
+            <Tabs>
+                {siteSections.map((section) => {
+                    return MenuItem(section)
+                })}
+                <Tab component={Link} className={styles.menuItemRight} href={siteSourceUrl} icon={<MarkGithubIcon verticalAlign="middle" size={24} />} sx={{ width: "30px" }} />
+            </Tabs>
         </AppBar >
     );
 }

--- a/web/components/siteMenu.js
+++ b/web/components/siteMenu.js
@@ -7,6 +7,7 @@ import { Typography } from '@mui/material';
 import { MarkGithubIcon } from '@primer/octicons-react'
 import { getCurrentSection } from '../lib/utils';
 import { siteSections, siteSourceUrl } from "../lib/settings";
+import { Tab, Tabs } from "@mui/material"
 import styles from './siteMenu.module.css';
 
 export default function SiteMenu() {

--- a/web/components/siteMenu.module.css
+++ b/web/components/siteMenu.module.css
@@ -11,6 +11,7 @@
 /* Change the link color to #111 (black) on hover */
 .menuItem:hover {
     background-color: #111;
+    text-decoration: none;
 }
 
 .menuItemActive {
@@ -23,29 +24,7 @@
     background-color: white;
 }
 
-.menuLink {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    background-color: inherit;
-    color: inherit;
-    text-decoration: none;
-}
-
-/* Change the link color to #111 (black) on hover */
-.menuLink:hover {
-    background-color: #111;
-    text-decoration: none;
-}
-
-.menuLinkActive {
-    composes: menuLink;
-    color: black;
-}
-
-/* Don't change the link color on hover for the active section */
-.menuLinkActive:hover {
-    background-color: white;
-    color: black;
-    text-decoration: none;
+.menuItemRight {
+    composes: menuItem;
+    margin-left: auto;
 }

--- a/web/components/siteMenu.module.css
+++ b/web/components/siteMenu.module.css
@@ -14,16 +14,19 @@
     text-decoration: none;
 }
 
+/* The active section has a white background to match the default site color */
 .menuItemActive {
     composes: menuItem;
     color: black;
     background-color: white;
 }
 
+/* Don't change the color of the active section on hover */
 .menuItemActive:hover {
     background-color: white;
 }
 
+/* This class right-aligns menu items to which it is assigned */
 .menuItemRight {
     composes: menuItem;
     margin-left: auto;

--- a/web/pages/_app.js
+++ b/web/pages/_app.js
@@ -14,16 +14,6 @@ const theme = createTheme({
             main: grey[800],
         },
     },
-    components: {
-        MuiToolbar: {
-            styleOverrides: {
-                dense: {
-                    height: "100%",
-                    textAlign: "center",
-                }
-            }
-        },
-    },
 });
 
 export default function App({ Component, pageProps }) {


### PR DESCRIPTION
Convert site menu bar to Material UI tabs.

These are simpler and cleaner than the custom job I was doing before. The main hiccup was getting the tabs to behave like Next.js Link components (preserving the nice client-side routing behavior that Next.js Links provide). This allowed me to delete a bunch of code. Huzzah!